### PR TITLE
Node label with icon and ellipses

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -391,7 +391,7 @@ const data = {
   'nodes': [
     { 'id': 'A1', 'data': {'label': 'Alice', 'group': 'A', 'gender': 'female', 'is_active': true}},
     { 'id': 'A2', 'data': {'label': 'Bob', 'group': 'A', 'gender': 'male', 'is_active': true}},
-    { 'id': 'A3', 'data': {'label': 'Charlie', 'group': 'A', 'gender': 'male', 'is_active': true}},
+    { 'id': 'A3', 'data': {'label': 'CharlieCharlieCharlie', 'group': 'A', 'gender': 'male', 'is_active': true}},
     { 'id': 'A4', 'data': {'label': 'Diana', 'group': 'A', 'gender': 'female', 'is_active': true}},
     { 'id': 'A5', 'data': {'label': 'Eve', 'group': 'A', 'gender': 'female', 'is_active': true}},
     { 'id': 'A6', 'data': {'label': 'Frank', 'group': 'A', 'gender': 'male'}},
@@ -498,7 +498,7 @@ const options = {
         nodeTypeAccessor: (node) => node.getData()?.group,
         nodeStyleMap: {
             'A': { shape: 'hexagon', color: 'var(--pvt-theme-secondary)', size: 38, text: (node) => node.getData()?.label, textVerticalShift: -1 },
-            'B': { shape: 'circle', color: 'var(--pvt-vibrant-blue)', svgIcon: (node) => node.getData()?.icon },
+            'B': { shape: 'circle', color: 'var(--pvt-vibrant-blue)', svgIcon: (node) => node.getData()?.icon, text: (node) => node.getData()?.label, textVerticalShift: 1 },
             'C': { shape: 'square', color: 'var(--pvt-vibrant-indigo)', size: 18 },
             'D': { color: 'var(--pvt-vibrant-green)', size: 22 },
         },

--- a/src/renderers/svg/NodeDrawer.ts
+++ b/src/renderers/svg/NodeDrawer.ts
@@ -303,16 +303,6 @@ export class NodeDrawer {
                 .attr('y', -style.size * (scale/2))
                 .attr('width', style.size * scale)
                 .attr('height', style.size * scale)
-        } else if (style.text) {
-            nodeSelection
-                .append('text')
-                .attr('text-anchor', 'middle')
-                .attr('y', - style.textVerticalShift * (style.size + 5))
-                .attr('dominant-baseline', 'central')
-                .attr('font-size', this.computeFontSize(style.text, style.size, style.textVerticalShift))
-                .attr('font-family', style.fontFamily)
-                .attr('fill', style.textColor)
-                .text(style.text)
         } else if (style.html) {
             const fo = nodeSelection.append('foreignObject')
             const rendered = style.html(node)
@@ -326,6 +316,18 @@ export class NodeDrawer {
             } else if (rendered instanceof HTMLElement) {
                 fo.node()?.append(rendered)
             }
+        }
+        // Do not have text dislay be mutually exclusive with icons
+        if (style.text) {
+            nodeSelection
+                .append('text')
+                .attr('text-anchor', 'middle')
+                .attr('y', - style.textVerticalShift * (style.size + 5))
+                .attr('dominant-baseline', 'central')
+                .attr('font-size', this.computeFontSize(style.text, style.size, style.textVerticalShift))
+                .attr('font-family', style.fontFamily)
+                .attr('fill', style.textColor)
+                .text(style.text)
         }
     }
 

--- a/src/renderers/svg/NodeDrawer.ts
+++ b/src/renderers/svg/NodeDrawer.ts
@@ -319,15 +319,16 @@ export class NodeDrawer {
         }
         // Do not have text dislay be mutually exclusive with icons
         if (style.text) {
+            const [fontSize, text] = this.computeTextLayout(style.text, style.size, style.textVerticalShift)
             nodeSelection
                 .append('text')
                 .attr('text-anchor', 'middle')
-                .attr('y', - style.textVerticalShift * (style.size + 5))
+                .attr('y', - style.textVerticalShift * (style.size + fontSize/2*1.2))
                 .attr('dominant-baseline', 'central')
-                .attr('font-size', this.computeFontSize(style.text, style.size, style.textVerticalShift))
+                .attr('font-size', fontSize)
                 .attr('font-family', style.fontFamily)
                 .attr('fill', style.textColor)
-                .text(style.text)
+                .text(text)
         }
     }
 
@@ -400,22 +401,28 @@ export class NodeDrawer {
         }
     }
 
-    private computeFontSize(label: string, nodeSize: number, textVerticalShift: number = 0) {
-        const base = nodeSize * 0.8
+    private computeTextLayout(label: string, nodeSize: number, textVerticalShift: number = 0): [number, string] {
+        const base = nodeSize * 0.9
         // Allow wider strings when text is outside the node
-        const maxWidth = Math.abs(textVerticalShift) >= 1 ? nodeSize * 3.8 : nodeSize * 1.6
-        // Limit the font size for short text
-        const maxFontSize = nodeSize * 0.5
+        const maxWidth = Math.abs(textVerticalShift) >= 1 ? base * 6 : base * 2
+        // Scale font to node size
+        const fontSize = base * 0.5
  
-        // approximate width: ~0.6em per character
-        const estWidth = label.length * base * 0.6
-        var scale = 1
+        // Approximate width: ~0.5em per character
+        // On average this should render nicely but not all characters are equal width
+        const charWidth = base * 0.5
+        const maxChars = Math.floor(maxWidth / charWidth)
 
-        if (estWidth > maxWidth) {
-            scale = maxWidth / estWidth
+        if (label.length > maxChars && label.length > 7) {
+            // Since text is too long, add ellipsis
+            const charsToKeep = Math.max(6, maxWidth / charWidth) - 1 // Reserve 1 space for "..."
+
+            const tailChars = Math.min(3, Math.floor(charsToKeep / 2))
+            const headChars = charsToKeep - tailChars
+            label = label.slice(0, headChars) + '...' + label.slice(label.length - tailChars)
         }
 
-        return Math.min(base * scale, maxFontSize)
+        return [fontSize, label]
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Updated label to not be mutually exclusive with an icon.
Removed shrinking text (so same sized nodes have same sized labels) and implemented ellipsis replacement.

Some things to consider, but it already was like this:
- Since we are not using a mono-spaced font, some extreme labels "mmm" will have different final widths than others "iii"
- Label size scales to node size, meaning small nodes have labels that are hard to read without zooming in.

<img width="726" height="463" alt="pivotick_label_rework" src="https://github.com/user-attachments/assets/83f50102-0172-449e-ae41-0151bcaa7d6a" />
