### PR TITLE
Improved Neighbors UI

### DIFF
--- a/src/interfaces/GraphUI.ts
+++ b/src/interfaces/GraphUI.ts
@@ -177,6 +177,7 @@ export interface Tooltip {
     * (element) => `element id: ${element.id}`
     */
     render?: ((element: Node | Edge) => HTMLElement | string) | HTMLElement | string,
+    setPosition?: (tooltip: HTMLElement, hoveredBCR: DOMRect, canvasBbox: DOMRect) => void, 
 }
 
 export interface Navigation {

--- a/src/ui/elements/Sidebar/Neighbors.ts
+++ b/src/ui/elements/Sidebar/Neighbors.ts
@@ -259,8 +259,12 @@ export class SidebarNeighbors implements UIElement {
             UI: {
                 mode: 'viewer',
                 tooltip: {
-                    enabled: false,
+                    enabled: true,
                     allowPinning: false,
+                    setPosition: (tooltip: HTMLElement, hoveredBCR: DOMRect, canvasBbox: DOMRect) => {
+                        tooltip.style.left = `${canvasBbox.x+canvasBbox.width + 15}px`
+                        tooltip.style.top = `${canvasBbox.y}px`
+                    }
                 },
                 contextMenu: {
                     enabled: false,
@@ -290,16 +294,30 @@ export class SidebarNeighbors implements UIElement {
                 cooldownTime: 0,
             },
             callbacks: {
+                onNodeClick: (_evt, node) => {
+                    const mainGraphNode = this.uiManager.graph.getMutableNode(node.id)
+                    if (mainGraphNode){
+                        if (this.uiManager.graph.renderer.getGraphInteraction().getSelectedNode()?.node != mainGraphNode) {
+                            this.uiManager.graph.unHighlightElement(mainGraphNode)
+                            this.egoGraph?.unHighlightElement(node)
+                            this.uiManager.graph.selectElement(mainGraphNode)
+                        }
+                    }
+                },
                 onNodeHoverIn: (_evt, node) => {
                     const mainGraphNode = this.uiManager.graph.getMutableNode(node.id)
                     if (mainGraphNode) {
                         this.uiManager.graph.highlightElement(mainGraphNode)
+                        this.egoGraph?.highlightElement(node)
+                        this.egoGraph?.UIManager.tooltip?.nodeHovered(_evt, node)
+                        
                     }
                 },
                 onNodeHoverOut: (_evt, node) => {
                     const mainGraphNode = this.uiManager.graph.getMutableNode(node.id)
                     if (mainGraphNode) {
                         this.uiManager.graph.unHighlightElement(mainGraphNode)
+                        this.egoGraph?.unHighlightElement(node)
                     }
                 },
             }
@@ -314,6 +332,9 @@ export class SidebarNeighbors implements UIElement {
                 this.egoGraph!.selectElement(this.egoGraph!.getMutableNode(egoNode.id)!)
             }
         })
+
+        // Overwrite the canvasclick so that clicking on the small canvas doesn't deselect the node 
+        this.egoGraph.renderer.getGraphInteraction().canvasClick = () => {}
     }
 
     private buildList(node: Node) {

--- a/src/ui/elements/Tooltip/Tooltip.ts
+++ b/src/ui/elements/Tooltip/Tooltip.ts
@@ -359,6 +359,12 @@ export class Tooltip implements UIElement {
         const canvasBbox = this.uiManager.layout?.canvas?.getBoundingClientRect()
         if (!canvasBbox) return
 
+        const setPositionCb = this.uiManager.getOptions().tooltip.setPosition
+        if (setPositionCb && typeof setPositionCb === 'function') {
+            setPositionCb(this.tooltip, hoveredBCR, canvasBbox)
+            return
+        }
+
         const offset = 20 // Extra offset to give more space around the tooltip
         const offsetX = 15 // Offset between the tooltip and the hovered element on the X axis
 


### PR DESCRIPTION
The neighbor nodes in the sidebar are now selectable. You can also hover over them to see the tooltip. 
The setPositions of the Tooltip have been changed so that you can customize the position.