### PR TITLE
fix: [edge] remove duplicated edge

### DIFF
--- a/src/renderers/svg/NoteDrawer.ts
+++ b/src/renderers/svg/NoteDrawer.ts
@@ -213,12 +213,10 @@ export class NoteDrawer {
 
                 linkContent.appendChild(row)
 
-                const rootHtml = root as unknown as HTMLElement
-                this.graph.UIManager.tooltip?.shadowLinkManager?.removeShadowLink(rootHtml)
-
                 requestAnimationFrame(() => {
                     const rootHtml = root as unknown as HTMLElement
                     const shadowLinkManager = this.graph.UIManager.tooltip?.shadowLinkManager
+                    shadowLinkManager?.removeShadowLink(rootHtml)
                     shadowLinkManager?.setBoundingBox(rootHtml, {
                         source: rootHtml.getBoundingClientRect(),
                         target: node.getGraphElement()!.getBoundingClientRect(),


### PR DESCRIPTION
Adding a link to notes with the search bar creates a second edge that remains static and does not get cleaned up.

<img width="662" height="446" alt="Kooha-2026-07-10-01-33-15" src="https://github.com/user-attachments/assets/21c0e1e7-dafe-4d4a-a8ec-7efea2bec695" />

This seems to be because in `src/renderers/svg/NoteDrawer.ts` we have:
```ts
const searchBtn = createButton({
    ...
    onClick: async (evt: MouseEvent) => {
        ...
        note.setAttachedElement({ type: 'node', 'id': ((node as unknown) as Node).id })
        this.graph.noteManager.editNote(note)
        this.refreshLink(note)  // One refresh here
    }
})
```
But `note.setAttachedElement()` sets the note as dirty which triggers this in `src/renderers/svg/GraphSvgRenderer.ts`:
```ts
if (note.isAttachmentDirty()) {
    this.noteDrawer.refreshLink(note)  // Another refresh here
    note.clearAttachmentDirty()
}
```

This fix moves `removeShadowLink(rootHtml)` inside `requestAnimationFrame` in case we ever have multiple calls.

<img width="1098" height="644" alt="Kooha-2026-07-10-02-22-01" src="https://github.com/user-attachments/assets/7d73248b-8b02-4c8b-aded-2b5c7c5e503f" />
