### PR TITLE
fix: [sidebar] push up z index

### DIFF
--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -44,6 +44,8 @@
     width: var(--pvt-sidebar-width);
     grid-area: sidebar;
     height: 100%;
+    position: relative;
+    z-index: 1;
     transition: width 0.1s ease-out;
 
     .pvt-sidebar-elements {


### PR DESCRIPTION
The sidebar would have the note-node edge drawn overtop of it as they have the same z-index. Pushing the z-index of the sidebar up by 1 fixes the overlap.

With the overlap:
<img width="584" height="375" alt="pivotick_edge_over_border" src="https://github.com/user-attachments/assets/64ae9b75-e6b8-4760-9966-2b1e75fc6039" />

Without the overlap:
<img width="569" height="318" alt="pivotick_edge_over_border_fix" src="https://github.com/user-attachments/assets/3873f1dc-9a7b-4afb-8956-ebec59684bb6" />
