### PR TITLE
fix: [edge] move edge drawing into GraphSvgRenderer from NoteDrawer

### DIFF
--- a/src/renderers/svg/GraphSvgRenderer.ts
+++ b/src/renderers/svg/GraphSvgRenderer.ts
@@ -254,6 +254,7 @@ export class GraphSvgRenderer extends GraphRenderer {
     private edgeGroup: Selection<SVGGElement, unknown, null, undefined>
     private nodeGroup: Selection<SVGGElement, unknown, null, undefined>
     private noteGroup: Selection<SVGGElement, unknown, null, undefined>
+    private noteEdgeGroup: Selection<SVGGElement, unknown, null, undefined>
     private selectionBoxGroup: Selection<SVGGElement, unknown, null, undefined>
     public defs: Selection<SVGDefsElement, unknown, null, undefined>
 
@@ -267,6 +268,7 @@ export class GraphSvgRenderer extends GraphRenderer {
     private nodeGroupSelection!: Selection<SVGGElement, Node, SVGGElement, unknown>
     private edgeGroupSelection!: Selection<SVGPathElement, Edge, SVGGElement, unknown>
     private noteGroupSelection!: Selection<SVGGElement, Note, SVGGElement, unknown>
+    private noteEdgeSelection!: Selection<SVGPathElement, { note: Note; target: Node }, SVGGElement, unknown>
     private nodeSelection!: Selection<SVGGElement, Node, SVGGElement, unknown>
     private edgeSelection!: Selection<SVGGElement, Edge, SVGGElement, unknown>
     private noteSelection!: Selection<SVGGElement, Note, SVGGElement, unknown>
@@ -302,6 +304,8 @@ export class GraphSvgRenderer extends GraphRenderer {
 
         this.shadowEdgeGroup = this.zoomGroup.append('g').attr('class', 'shadow-edges').style('pointer-events', 'none')
         this.shadowEdgePath = this.shadowEdgeGroup.append('path').attr('class', 'pvt-shadow-edge').style('display', 'none')
+
+        this.noteEdgeGroup = this.zoomGroup.append('g').attr('class', 'note-edges')
         
         this.noteGroup = this.zoomGroup.append('g').attr('class', 'notes')
         this.selectionBoxGroup = this.svg.append('g').attr('class', 'selection-box')
@@ -599,6 +603,34 @@ export class GraphSvgRenderer extends GraphRenderer {
 
                 exit => exit.remove()
             )
+
+        // Builds array of note target pairs
+        const noteEdges: { note: Note; target: Node }[] = []
+        for (const note of this.graph.noteManager.getVisibleNotes()) {
+            const attached = note.getAttachedElement()
+            if (!attached || attached.type !== 'node') continue
+            const target = this.graph.getMutableNode(attached.id)
+            if (!target || !target.visible) continue
+            noteEdges.push({ note, target })
+        }
+
+        this.noteEdgeSelection = this.noteEdgeGroup
+            .selectAll<SVGPathElement, { note: Note; target: Node }>('path')
+            .data(noteEdges, d => d.note.id)
+            .join(
+                enter => enter
+                    .append('path')
+                    .attr('class', 'pvt-note-edge')
+                    .attr('stroke', 'var(--pvt-edge-stroke, #999)')
+                    .attr('stroke-width', 2)
+                    .attr('stroke-dasharray', '6 4')
+                    .attr('fill', 'none')
+                    .attr('opacity', 0.7)
+                    .attr('d', d => this.noteEdgePath(d.note, d.target)),
+                update => update
+                    .attr('d', d => this.noteEdgePath(d.note, d.target)),
+                exit => exit.remove()
+            )
     }
 
     public getCanvasSelection(): Selection<SVGSVGElement, unknown, null, undefined> {
@@ -611,6 +643,7 @@ export class GraphSvgRenderer extends GraphRenderer {
 
     public nextTick(): void {
         this.updateEdgePositions() // Render edges first so nodes are drawn on top of them
+        this.updateNoteEdgePositions()
         this.updateNotePositions()
         this.updateNodePositions()
     }
@@ -820,6 +853,44 @@ export class GraphSvgRenderer extends GraphRenderer {
         } else {
             this.edgeDrawer.updatePositions(this.edgeSelection)
         }
+    }
+
+    private updateNoteEdgePositions(): void {
+        if (!this.noteEdgeSelection) return
+        this.noteEdgeSelection.attr('d', d => this.noteEdgePath(d.note, d.target))
+    }
+
+    private noteEdgePath(note: Note, target: Node): string | null {
+        const left = note.x
+        const right = note.x + note.width
+        const top = note.y
+        const bottom = note.y + note.height
+
+        const targetX = target.x ?? 0
+        const targetY = target.y ?? 0
+
+        const closestX = Math.max(left, Math.min(targetX, right))
+        const closestY = Math.max(top, Math.min(targetY, bottom))
+
+        const dx = targetX - closestX
+        const dy = targetY - closestY
+        const dist = Math.hypot(dx, dy)
+
+        if (dist === 0) return null
+
+        const nx = dx / dist
+        const ny = dy / dist
+
+        const drawOffsetStart = 4
+        const startX = closestX + nx * drawOffsetStart
+        const startY = closestY + ny * drawOffsetStart
+
+        const rTo = target.getCircleRadius() || this.nodeDrawer.getNodeStyle(target).size as number
+        const drawOffsetEnd = 8
+        const endX = targetX - nx * (rTo + drawOffsetEnd)
+        const endY = targetY - ny * (rTo + drawOffsetEnd)
+
+        return `M ${startX},${startY} L ${endX},${endY}`
     }
 
     private updateNotePositions(): void {

--- a/src/renderers/svg/NoteDrawer.ts
+++ b/src/renderers/svg/NoteDrawer.ts
@@ -39,21 +39,6 @@ export class NoteDrawer {
         this.graph = graph
         this.graphSvgRenderer = graphSvgRenderer
         this.noteContentRenderer = new NoteContentRenderer(this.graph)
-
-        this.graph.on('ready', () => {
-            this.graphSvgRenderer.getGraphInteraction().on('canvasZoom', this.canvasZoomed.bind(this))
-            this.graphSvgRenderer.getGraphInteraction().on('simulationSlowTick', this.simulationSlowTick.bind(this))
-        })
-    }
-
-    private canvasZoomed() {
-        this.updateShadowLinkBoundBoxes()
-        this.updateShadowLinks()
-    }
-
-    private simulationSlowTick() {
-        this.updateShadowLinkBoundBoxes()
-        this.updateShadowLinks()
     }
 
     public render(noteSelection: Selection<SVGGElement, Note, null, undefined>, note: Note): void {
@@ -204,28 +189,12 @@ export class NoteDrawer {
                         note.setAttachedElement(undefined)
                         this.graph.noteManager.editNote(note)
                         this.refreshLink(note)
-                        const rootHtml = root as unknown as HTMLElement
-                        this.graph.UIManager.tooltip?.shadowLinkManager?.removeShadowLink(rootHtml)
                     },
                 })
 
                 row.appendChild(unlinkButton)
 
                 linkContent.appendChild(row)
-
-                const rootHtml = root as unknown as HTMLElement
-                this.graph.UIManager.tooltip?.shadowLinkManager?.removeShadowLink(rootHtml)
-
-                requestAnimationFrame(() => {
-                    const rootHtml = root as unknown as HTMLElement
-                    const shadowLinkManager = this.graph.UIManager.tooltip?.shadowLinkManager
-                    shadowLinkManager?.setBoundingBox(rootHtml, {
-                        source: rootHtml.getBoundingClientRect(),
-                        target: node.getGraphElement()!.getBoundingClientRect(),
-                    })
-                    shadowLinkManager?.addShadowLink(rootHtml)
-                    shadowLinkManager?.updateShadowLink(rootHtml, this.getShadowLinkSourcePoint(rootHtml), false)
-                })
             } else {
                 const unresolved = document.createElement('span')
                 unresolved.classList.add('pvt-node-reference', 'unresolved')
@@ -246,28 +215,6 @@ export class NoteDrawer {
             linkContent.appendChild(empty)
         }
     }
-
-    /**
-     * Screen-space start point for a note's shadow link: the note's left edge at
-     * the vertical centre of its link handle. Measured live from the rendered DOM
-     * every draw, so it stays correct across zoom, drag and the note's initial
-     * layout settling. The shadow link path is drawn in screen coordinates (see
-     * ShadowLinkManager), matching how the target point is taken from the node's
-     * bounding box. Falls back to the note's top edge if the handle isn't laid
-     * out yet (e.g. the first frame after a note is linked at construction time).
-     */
-    private getShadowLinkSourcePoint(noteEl: HTMLElement): { x: number, y: number } {
-        const noteBCR = noteEl.getBoundingClientRect()
-        const handle = noteEl.querySelector('.pvt-note-link-placeholder-icon') as HTMLElement | null
-        const handleBCR = handle?.getBoundingClientRect()
-
-        const y = handleBCR && handleBCR.height > 0
-            ? handleBCR.top + handleBCR.height / 2 - 5 // -5 for slightly better ui
-            : noteBCR.top
-        return { x: noteBCR.left, y }
-    }
-
-    // Move shadowlink start point on note depending on target direction
 
     private createContent(note: Note): HTMLDivElement {
         const div = document.createElement('div')
@@ -353,11 +300,6 @@ export class NoteDrawer {
             size: 'xs',
             onClick: () => {
                 this.graph.noteManager.removeNote(note)
-                const root = note.getGraphElement()
-                if (root) {
-                    const rootHtml = root as unknown as HTMLElement
-                    this.graph.UIManager.tooltip?.shadowLinkManager?.removeShadowLink(rootHtml)
-                }
             }
         })
 
@@ -517,37 +459,6 @@ export class NoteDrawer {
         })
     }
 
-    private updateShadowLinkBoundBoxes(): void {
-        const shadowLinkManager = this.graph.UIManager.tooltip?.shadowLinkManager
-
-        this.graph.getNotes().forEach(note => {
-
-            const attached = note.getAttachedElement()
-            if (attached && attached.type === 'node') {
-                const node = this.graph.getMutableNode(attached.id)
-                if (node) {
-                    const root = note.getGraphElement()
-                    const rootHtml = root as unknown as HTMLElement
-                    shadowLinkManager?.setBoundingBox(rootHtml, {
-                        source: rootHtml.getBoundingClientRect(),
-                        target: node.getGraphElement()!.getBoundingClientRect(),
-                    })
-                }
-            }
-        })
-    }
-
-    private updateShadowLinks(): void {
-        const shadowLinkManager = this.graph.UIManager.tooltip?.shadowLinkManager
-        for (const note of this.graph.getNotes()) {
-            if (!note.getAttachedElement()) continue
-            const noteEl = note.getGraphElement() as unknown as HTMLElement | null
-            if (noteEl) {
-                shadowLinkManager?.updateShadowLink(noteEl, this.getShadowLinkSourcePoint(noteEl), false)
-            }
-        }
-    }
-
     private makeDraggable(noteSelection: Selection<SVGGElement, Note, null, undefined>, note: Note): void {
 
         const header = noteSelection.select<SVGRectElement>('.pvt-note-header')
@@ -590,7 +501,7 @@ export class NoteDrawer {
                     window.getSelection()?.removeAllRanges()
                     document.body.classList.add('pvt-disable-selection') // disable selection globally
 
-                    this.updateShadowLinks()
+                    this.graphSvgRenderer.nextTick()
                 }
 
                 const onMouseUp = () => {
@@ -667,12 +578,7 @@ export class NoteDrawer {
 
                 this.updateNoteSize(noteSelection, note)
 
-                // Resizing changes the note's width/height, so refresh both the
-                // cached source bounding box (used to anchor the link to the
-                // note's edge) and the link itself, rather than waiting for the
-                // next tick or pan.
-                this.updateShadowLinkBoundBoxes()
-                this.updateShadowLinks()
+                this.graphSvgRenderer.nextTick()
             }
 
             const onMouseUp = () => {


### PR DESCRIPTION
Moved the drawing of the note-node edges into `GraphSvgRenderer.ts` rather than `NoteDrawer.ts`. This fixes the layering issues mentioned in #21 and has edges be redrawn automatically with checks on neighbours to fix #22.
Since the rendering is changed, the bug fixes in #20 and #21 are no longer required.

In `GraphSvgRenderer.ts`:
- Adds `noteEdgeGroup` and `noteEdgeSelection`
- Adds note-node edges in `dataUpdate()` which filters for visible nodes
- Calculation of path in `noteEdgePath()` to the closest edge of the note and has spacing around nodes, similar to normal edges and means the edge does not connect to the middle of the node anymore.

In `NoteDrawer.ts`:
- Removed need to know `canvasZoom` and `simulationSlowTick`
- Removes the drawing of the edges
- Adds `this.graphSvgRenderer.nextTick()` for when the nodes are moved or resized

Shows new edge layering:
<img width="288" height="300" alt="pivotick_new_edge" src="https://github.com/user-attachments/assets/4c4de7f4-5fa4-4a3b-98d6-6f9171864800" />
