### PR TITLE
chg: [hitbox] anchor edges on the node's actual shape instead of a bounding circle

### DIFF
--- a/src/Node.ts
+++ b/src/Node.ts
@@ -66,8 +66,8 @@ export class Node {
     private _subgraph?: Graph
     private _circleRadius = this.defaultCircleRadius
     private _circleRadiusCollapsed = this.defaultCircleRadius
-    // TEMP (feature/node-hitboxes): measured bounding box, for shape-aware edge anchoring
-    // on custom-path nodes (undefined until NodeDrawer measures the rendered shape).
+    // Measured bounding box, used to anchor edges on the node's actual border instead
+    // of a bounding circle (undefined until NodeDrawer measures the rendered shape).
     private _boxHalfWidth?: number
     private _boxHalfHeight?: number
     private _dirty: boolean

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -66,6 +66,10 @@ export class Node {
     private _subgraph?: Graph
     private _circleRadius = this.defaultCircleRadius
     private _circleRadiusCollapsed = this.defaultCircleRadius
+    // TEMP (feature/node-hitboxes): measured bounding box, for shape-aware edge anchoring
+    // on custom-path nodes (undefined until NodeDrawer measures the rendered shape).
+    private _boxHalfWidth?: number
+    private _boxHalfHeight?: number
     private _dirty: boolean
     public readonly domID: string
 
@@ -361,6 +365,19 @@ export class Node {
 
     getCircleRadiusCollapsed(): number {
         return this._circleRadiusCollapsed
+    }
+
+    setBoxSize(width: number, height: number): void {
+        this._boxHalfWidth = width / 2
+        this._boxHalfHeight = height / 2
+    }
+
+    getBoxHalfWidth(): number | undefined {
+        return this._boxHalfWidth
+    }
+
+    getBoxHalfHeight(): number | undefined {
+        return this._boxHalfHeight
     }
 
     setChildren(children: Node[]): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -439,10 +439,6 @@ const data = {
     { 'id': 'D3', 'data': {'label': 'Uma', 'group': 'D', 'gender': 'female'}},
     { 'id': 'D4', 'data': {'label': 'Victor', 'group': 'D', 'gender': 'male'}},
     { 'id': 'D5', 'data': {'label': 'Walter', 'group': 'D', 'gender': 'male'}},
-    // TEMP (feature/node-hitboxes): rectangle demo nodes
-    { 'id': 'E1', 'data': {'label': 'Rect 1', 'group': 'E'}},
-    { 'id': 'E2', 'data': {'label': 'Rect 2', 'group': 'E'}},
-    { 'id': 'E3', 'data': {'label': 'Rect 3', 'group': 'E'}},
     { 'id': 'D6', 'data': {'label': 'Xavier', 'group': 'D', 'gender': 'male'}, children: [
         {
             'id': 'children-1',
@@ -505,13 +501,6 @@ const data = {
     { 'from': 'C3', 'to': 'D2' },
     { 'from': 'D4', 'to': 'A6' },
 
-    // TEMP (feature/node-hitboxes): rectangle demo edges — straight, mixed angles
-    { 'from': 'E1', 'to': 'E2' },
-    { 'from': 'E2', 'to': 'E3' },
-    { 'from': 'A1', 'to': 'E1' },
-    { 'from': 'E1', 'to': 'C1' },
-    { 'from': 'B1', 'to': 'E3' },
-
     // { 'from': 'children-1', 'to': 'children-2', 'data': { 'label': 'c1-c2' } },
     //   { 'from': 'children-2', 'to': 'children-3', 'data': { 'label': 'c2-c3' } },
     //   { 'from': 'children-3', 'to': 'children-1', 'data': { 'label': 'c3-c1' } },
@@ -539,9 +528,6 @@ const options = {
             'B': { shape: 'circle', color: 'var(--pvt-vibrant-blue)', svgIcon: (node) => node.getData()?.icon, text: (node) => node.getData()?.label, textVerticalShift: 1 },
             'C': { shape: 'square', color: 'var(--pvt-vibrant-indigo)', size: 18 },
             'D': { color: 'var(--pvt-vibrant-green)', size: 22 },
-            // TEMP (feature/node-hitboxes): true (non-square) rectangle via a custom SVG
-            // path shape — 'square' is always width===height, this is a real w!==h case.
-            'E': { shape: { d: 'M -40,-15 L 40,-15 L 40,15 L -40,15 Z' }, color: '#e67e22' },
         },
         defaultEdgeStyle: {
             dashed: (e) => { return e.getData().cool },

--- a/src/main.ts
+++ b/src/main.ts
@@ -439,6 +439,10 @@ const data = {
     { 'id': 'D3', 'data': {'label': 'Uma', 'group': 'D', 'gender': 'female'}},
     { 'id': 'D4', 'data': {'label': 'Victor', 'group': 'D', 'gender': 'male'}},
     { 'id': 'D5', 'data': {'label': 'Walter', 'group': 'D', 'gender': 'male'}},
+    // TEMP (feature/node-hitboxes): rectangle demo nodes
+    { 'id': 'E1', 'data': {'label': 'Rect 1', 'group': 'E'}},
+    { 'id': 'E2', 'data': {'label': 'Rect 2', 'group': 'E'}},
+    { 'id': 'E3', 'data': {'label': 'Rect 3', 'group': 'E'}},
     { 'id': 'D6', 'data': {'label': 'Xavier', 'group': 'D', 'gender': 'male'}, children: [
         {
             'id': 'children-1',
@@ -501,6 +505,13 @@ const data = {
     { 'from': 'C3', 'to': 'D2' },
     { 'from': 'D4', 'to': 'A6' },
 
+    // TEMP (feature/node-hitboxes): rectangle demo edges — straight, mixed angles
+    { 'from': 'E1', 'to': 'E2' },
+    { 'from': 'E2', 'to': 'E3' },
+    { 'from': 'A1', 'to': 'E1' },
+    { 'from': 'E1', 'to': 'C1' },
+    { 'from': 'B1', 'to': 'E3' },
+
     // { 'from': 'children-1', 'to': 'children-2', 'data': { 'label': 'c1-c2' } },
     //   { 'from': 'children-2', 'to': 'children-3', 'data': { 'label': 'c2-c3' } },
     //   { 'from': 'children-3', 'to': 'children-1', 'data': { 'label': 'c3-c1' } },
@@ -528,6 +539,9 @@ const options = {
             'B': { shape: 'circle', color: 'var(--pvt-vibrant-blue)', svgIcon: (node) => node.getData()?.icon, text: (node) => node.getData()?.label, textVerticalShift: 1 },
             'C': { shape: 'square', color: 'var(--pvt-vibrant-indigo)', size: 18 },
             'D': { color: 'var(--pvt-vibrant-green)', size: 22 },
+            // TEMP (feature/node-hitboxes): true (non-square) rectangle via a custom SVG
+            // path shape — 'square' is always width===height, this is a real w!==h case.
+            'E': { shape: { d: 'M -40,-15 L 40,-15 L 40,15 L -40,15 Z' }, color: '#e67e22' },
         },
         defaultEdgeStyle: {
             dashed: (e) => { return e.getData().cool },

--- a/src/renderers/svg/EdgeDrawer.ts
+++ b/src/renderers/svg/EdgeDrawer.ts
@@ -336,26 +336,26 @@ export class EdgeDrawer {
         return `M ${startX} ${startY} C ${cx1} ${cy1}, ${cx2} ${cy2}, ${endX} ${endY}`
     }
 
-    // TEMP (feature/node-hitboxes) test: shape-aware edge anchor radius.
-    // Square nodes anchor on their rectangular border; every other shape keeps
-    // the existing circle-radius approximation.
+    // Automatic, shape-agnostic edge anchor radius. Driven purely by the node's
+    // measured bounding box, not by its shape name — a
+    // roughly square/round box (circle, square, triangle, hexagon, ...) keeps the
+    // existing circle-radius approximation, which already fits those well; a box
+    // clearly longer on one axis (rectangles, elongated custom shapes) anchors on
+    // its actual rectangular border instead.
+    private static readonly RECT_ASPECT_THRESHOLD = 1.3
+
     private getNodeBorderRadius(node: Node, dirX: number, dirY: number): number {
-        const style = this.graphSvgRenderer.nodeDrawer.getNodeStyle(node)
-        const shape = typeof style.shape === 'function' ? style.shape(node) : style.shape
-
-        if (shape === 'square') {
-            const halfSize = tryResolveNumber(style.size, node) ?? node.getCircleRadius()
-            return rectRadiusAlongDirection(halfSize, halfSize, dirX, dirY)
-        }
-
-        // Custom-path shape: use its measured bounding box once NodeDrawer has it
-        // (falls back to the circle approximation on the first frame, before it's measured).
         const halfWidth = node.getBoxHalfWidth()
         const halfHeight = node.getBoxHalfHeight()
-        if (typeof shape === 'object' && shape !== null && halfWidth && halfHeight) {
-            return rectRadiusAlongDirection(halfWidth, halfHeight, dirX, dirY)
+
+        if (halfWidth && halfHeight) {
+            const aspectRatio = Math.max(halfWidth, halfHeight) / Math.min(halfWidth, halfHeight)
+            if (aspectRatio > EdgeDrawer.RECT_ASPECT_THRESHOLD) {
+                return rectRadiusAlongDirection(halfWidth, halfHeight, dirX, dirY)
+            }
         }
 
+        const style = this.graphSvgRenderer.nodeDrawer.getNodeStyle(node)
         return node.getCircleRadius() ? node.getCircleRadius() : tryResolveNumber(style.size, node) as number
     }
 

--- a/src/renderers/svg/EdgeDrawer.ts
+++ b/src/renderers/svg/EdgeDrawer.ts
@@ -1,6 +1,7 @@
 import { type Selection, select as d3Select } from 'd3-selection'
 import { Edge } from '../../Edge'
-import { getApproximateArcLengthAndMidpoint, getApproximateCircleArcLengthAndMidpoint, getArcIntersectionWithCircle, getSegmentLengthAndMidpoint, type ArcParams, type Circle } from '../../utils/GeometryHelper'
+import { getApproximateArcLengthAndMidpoint, getApproximateCircleArcLengthAndMidpoint, getArcIntersectionWithCircle, getSegmentLengthAndMidpoint, rectRadiusAlongDirection, type ArcParams, type Circle } from '../../utils/GeometryHelper'
+import type { Node } from '../../Node'
 import type { Graph } from '../../Graph'
 import type { GraphSvgRenderer } from './GraphSvgRenderer'
 import { tryResolveBoolean, tryResolveNumber, tryResolveString } from '../../utils/Getters'
@@ -335,6 +336,29 @@ export class EdgeDrawer {
         return `M ${startX} ${startY} C ${cx1} ${cy1}, ${cx2} ${cy2}, ${endX} ${endY}`
     }
 
+    // TEMP (feature/node-hitboxes) test: shape-aware edge anchor radius.
+    // Square nodes anchor on their rectangular border; every other shape keeps
+    // the existing circle-radius approximation.
+    private getNodeBorderRadius(node: Node, dirX: number, dirY: number): number {
+        const style = this.graphSvgRenderer.nodeDrawer.getNodeStyle(node)
+        const shape = typeof style.shape === 'function' ? style.shape(node) : style.shape
+
+        if (shape === 'square') {
+            const halfSize = tryResolveNumber(style.size, node) ?? node.getCircleRadius()
+            return rectRadiusAlongDirection(halfSize, halfSize, dirX, dirY)
+        }
+
+        // Custom-path shape: use its measured bounding box once NodeDrawer has it
+        // (falls back to the circle approximation on the first frame, before it's measured).
+        const halfWidth = node.getBoxHalfWidth()
+        const halfHeight = node.getBoxHalfHeight()
+        if (typeof shape === 'object' && shape !== null && halfWidth && halfHeight) {
+            return rectRadiusAlongDirection(halfWidth, halfHeight, dirX, dirY)
+        }
+
+        return node.getCircleRadius() ? node.getCircleRadius() : tryResolveNumber(style.size, node) as number
+    }
+
     private linkStraight(edge: Edge): string | null {
         const { from, to } = edge
         const isEdgeSelected = this.graphSvgRenderer.getGraphInteraction().getSelectedEdge()?.edge.id === edge.id
@@ -356,19 +380,17 @@ export class EdgeDrawer {
         let dy = to.y - from.y
         let distance = Math.sqrt(dx * dx + dy * dy)
 
-        let normX = dx / distance
-        let normY = dy / distance
-
-        // Compute source/target node radius
-        const rFrom = from.getCircleRadius() ? from.getCircleRadius() : this.graphSvgRenderer.nodeDrawer.getNodeStyle(from).size as number
-        const toNode = edge.getSubgraphToNode() ?? edge.to
-        const rTo = toNode.getCircleRadius() ? toNode.getCircleRadius() : this.graphSvgRenderer.nodeDrawer.getNodeStyle(toNode).size as number
-
         // From coordinate are taken from the center of the cluster node
         // If from and to overlap, take the translated node as origin
+        const normX = distance === 0 ? -Math.SQRT1_2 : dx / distance
+        const normY = distance === 0 ? -Math.SQRT1_2 : dy / distance
+
+        // Compute source/target node radius (shape-aware: see getNodeBorderRadius)
+        const toNode = edge.getSubgraphToNode() ?? edge.to
+        const rFrom = this.getNodeBorderRadius(from, normX, normY)
+        const rTo = this.getNodeBorderRadius(toNode, normX, normY)
+
         if (distance === 0) {
-            normX = -Math.SQRT1_2
-            normY = -Math.SQRT1_2
             dx = normX * rFrom
             dy = normY * rFrom
             distance = rFrom

--- a/src/renderers/svg/NodeDrawer.ts
+++ b/src/renderers/svg/NodeDrawer.ts
@@ -68,6 +68,10 @@ export class NodeDrawer {
                 const height = Math.ceil(bcr.height)
                 if (width === 0 || height === 0) return // never measurable: keep the fallback size
 
+                // Feed the measured box into the automatic edge-anchor calculation
+                // (EdgeDrawer.getNodeBorderRadius).
+                node.setBoxSize(width, height)
+
                 fo.attr('width', width)
                     .attr('height', height)
 
@@ -106,8 +110,8 @@ export class NodeDrawer {
                     height = Math.ceil(bbox.height)
                 }
 
-                // TEMP (feature/node-hitboxes): feed the measured box into the shape-aware
-                // edge-anchor calculation (EdgeDrawer.getNodeBorderRadius) for custom shapes.
+                // Feed the measured box into the automatic edge-anchor calculation
+                // (EdgeDrawer.getNodeBorderRadius).
                 node.setBoxSize(width, height)
 
                 if (this.rendererOptions.enableNodeExpansion && (!node.hasChildren() || !node.expanded)) {

--- a/src/renderers/svg/NodeDrawer.ts
+++ b/src/renderers/svg/NodeDrawer.ts
@@ -106,6 +106,10 @@ export class NodeDrawer {
                     height = Math.ceil(bbox.height)
                 }
 
+                // TEMP (feature/node-hitboxes): feed the measured box into the shape-aware
+                // edge-anchor calculation (EdgeDrawer.getNodeBorderRadius) for custom shapes.
+                node.setBoxSize(width, height)
+
                 if (this.rendererOptions.enableNodeExpansion && (!node.hasChildren() || !node.expanded)) {
                     if (this.getNodeStyle(node).shape == 'square') {
                         node.setCircleRadius(Math.SQRT1_2 * Math.max(width, height)) // Is the only shape that has a coord. shift

--- a/src/utils/GeometryHelper.ts
+++ b/src/utils/GeometryHelper.ts
@@ -150,6 +150,16 @@ export function getArcCenter(params: ArcParams): ArcCenterResult {
 }
 
 /**
+ * Distance from an axis-aligned rectangle's center to its border, along a
+ * (not necessarily unit) direction vector. Used to anchor edges on rectangular
+ * nodes instead of approximating them with a bounding circle.
+ */
+export function rectRadiusAlongDirection(halfWidth: number, halfHeight: number, dirX: number, dirY: number): number {
+    const ratio = Math.max(Math.abs(dirX) / halfWidth, Math.abs(dirY) / halfHeight)
+    return ratio === 0 ? halfWidth : 1 / ratio
+}
+
+/**
 * Find intersection points between two circles:
 * Circle 1: center (cx, cy), radius r
 * Circle 2: center (to.x, to.y), radius rTo


### PR DESCRIPTION
## Summary
- Edges were anchored on a single bounding-circle radius regardless of node shape, leaving visible gaps on non-round nodes (rectangles, elongated custom shapes) where the circle overshoots the actual outline.
- `EdgeDrawer.getNodeBorderRadius` now compares a node's measured bounding-box aspect ratio against a threshold: roughly square/round boxes (circle, square, triangle, hexagon, ...) keep the existing circle-radius approximation, which already fits them well; boxes clearly longer on one axis anchor on their actual rectangular border via a new `rectRadiusAlongDirection` helper.
- No shape-name special-casing — purely driven by measured geometry (`Node.setBoxSize`, fed from the same bounding-box measurements `NodeDrawer` already performs for the default render path and the `renderNode` custom-callback path).

## Scope / follow-ups
- Only `linkStraight` (straight edges) uses the new anchor calculation. Curved edges (`linkArc`), self-loops, note edges, and shadow/preview edges still use the old circle-only calculation — worth a follow-up if the same visual gap shows up there.
- `style.html` (per-node custom HTML content) is unaffected — its foreignObject stays a fixed `size*2` box and isn't measured, so it still anchors on the plain circle radius. Separate, pre-existing limitation, out of scope here.

## Test plan
- [x] `npx tsc --noEmit` — no new errors
- [x] `npx eslint` on touched files — clean
- [x] Full Playwright visual-regression suite (`npm run test:visual`) — 181/181 passing, no baseline changes
- [x] Manual check with a 4000-node synthetic graph (`bigrandom` topology) — no perf regression observed; micro-benchmark of the changed calculation shows ~0.6% of a 60fps frame budget at 10k edges